### PR TITLE
[AT-2430] Attempt to work around AGP 7.0.2 ExtractAnnotations task issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ jdk: openjdk11
 android:
   components:
     - tools
-    - android-29
-    - build-tools-29.0.2
+    - android-30
+    - build-tools-30.0.2
+
+before_install:
+  - yes | sdkmanager "platforms;android-30"
+
 script:
   - rm -Rf $HOME/.m2/repository/com/ibotta/gradle/aop/
   - ./publishLocal.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 os: linux
 dist: trusty
-jdk: openjdk11
+jdk: openjdk8
 sudo: required
 android:
   components:
@@ -13,22 +13,18 @@ android:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
 
-env:
-  global:
-    - JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.xml.bind'
-
 before_install:
   - chmod +x gradlew
   - yes | sdkmanager "platforms;android-30"
   - yes | sdkmanager "build-tools;30.0.2"
 
+before_script:
+  - chmod +x gradlew
+
 script:
   - rm -Rf $HOME/.m2/repository/com/ibotta/gradle/aop/
   - ./publishLocal.sh
   - ./gradlew build
-
-before_script:
-  - chmod +x gradlew
 
 install: skip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
 language: android
 os: linux
 dist: trusty
-jdk: openjdk8
+jdk: openjdk11
 sudo: required
 android:
   components:
-    - tools
-    - android-30
-    - build-tools-30.0.2
     - extra-android-m2repository
   licenses:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
 
-before_install:
-  - chmod +x gradlew
-  - yes | sdkmanager "platforms;android-30"
-  - yes | sdkmanager "build-tools;30.0.2"
+env:
+  global:
+    - TARGET_VERSION=30
+    - ANDROID_BUILD_TOOLS_VERSION=30.0.2
+    - ANDROID_HOME=~/android-sdk
 
+before_install:
+  - touch $HOME/.android/repositories.cfg
+  - wget "https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" -O commandlinetools.zip
+  - unzip commandlinetools.zip -d $ANDROID_HOME/
+  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager "platforms;android-${TARGET_VERSION}" --sdk_root=$ANDROID_HOME
+  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" --sdk_root=$ANDROID_HOME
+  
 before_script:
   - chmod +x gradlew
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ android:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
 
+env:
+  global:
+    - JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.xml.bind'
+
 before_install:
   - chmod +x gradlew
   - yes | sdkmanager "platforms;android-30"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ language: android
 os: linux
 dist: trusty
 jdk: openjdk11
-sudo: required
 android:
   components:
     - extra-android-m2repository
-  licenses:
-    - 'android-sdk-preview-license-.+'
-    - 'android-sdk-license-.+'
 
 env:
   global:
@@ -22,7 +18,7 @@ before_install:
   - unzip commandlinetools.zip -d $ANDROID_HOME/
   - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager "platforms;android-${TARGET_VERSION}" --sdk_root=$ANDROID_HOME
   - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" --sdk_root=$ANDROID_HOME
-  
+
 before_script:
   - chmod +x gradlew
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,29 @@ language: android
 os: linux
 dist: trusty
 jdk: openjdk11
+sudo: required
 android:
   components:
     - tools
     - android-30
     - build-tools-30.0.2
+    - extra-android-m2repository
+  licenses:
+    - 'android-sdk-preview-license-.+'
+    - 'android-sdk-license-.+'
 
 before_install:
+  - chmod +x gradlew
   - yes | sdkmanager "platforms;android-30"
+  - yes | sdkmanager "build-tools;30.0.2"
 
 script:
   - rm -Rf $HOME/.m2/repository/com/ibotta/gradle/aop/
   - ./publishLocal.sh
   - ./gradlew build
+
+before_script:
+  - chmod +x gradlew
 
 install: skip
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Plugin {
     const val DISPLAY_NAME = "Android AspectJ Gradle Plugin"
     const val JVM_TARGET = "1.8"
     private const val BUILD_NUMBER = "" // Dynamically updated by publishLocal.sh on Travis. Otherwise left as-is.
-    const val VERSION = "1.1.0$BUILD_NUMBER"
+    const val VERSION = "1.2.0$BUILD_NUMBER"
     val TAGS = listOf("Gradle", "Plugin", "Android", "AspectJ", "Kotlin", "Java")
 }
 
@@ -37,14 +37,14 @@ object Sdk {
 }
 
 object Versions {
-    const val ANDROID_BUILD_TOOLS_VERSION = "4.1.0"
+    const val ANDROID_BUILD_TOOLS_VERSION = "7.0.2"
     const val APPCOMPAT_VERSION = "1.1.0"
     const val ASPECTJ_VERSION = "1.9.6"
     const val GRADLE_PLUGIN_PUBLISH_VERSION = "0.12.0"
     const val JACOCO_ANDROID_VERSION = "0.2"
     const val JUNIT_VERSION = "5.7.0"
     const val KOTLIN_VERSION = "1.4.10"
-    const val KOTLIN_DSL_VERSION = "1.4.1"
+    const val KOTLIN_DSL_VERSION = "2.1.6"
     const val KOTLINX_SERIALIZATION_RUNTIME_VERSION = "0.20.0"
     const val MOCKITO_CORE_VERSION = "3.5.13"
     const val MOCKK_VERSION = "1.10.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/com/ibotta/gradle/aop/ExtFunctions.kt
+++ b/plugin/src/main/kotlin/com/ibotta/gradle/aop/ExtFunctions.kt
@@ -1,10 +1,10 @@
 package com.ibotta.gradle.aop
 
+import com.android.build.gradle.tasks.ExtractAnnotations
 import com.hiya.plugins.JacocoAndroidUnitTestReportExtension
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownDomainObjectException
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.AbstractCompile
@@ -15,6 +15,7 @@ private const val KAPT_TASK_TEMPLATE = "kapt%sKotlin"
 private const val JAVA_COMPILE_TASK_TEMPLATE = "compile%sJavaWithJavac"
 private const val KOTLIN_COMPILE_TASK_TEMPLATE = "compile%sKotlin"
 private const val JACOCO_REPORT_TASK_TEMPLATE = "jacocoTest%sUnitTestReport"
+private const val EXTRACT_ANNOTATIONS_TASK_TEMPLATE = "extract%sAnnotations"
 private const val JACOCO_ANDROID_REPORT_EXTENSION = "jacocoAndroidUnitTestReport"
 const val LANG_JAVA = "Java"
 const val LANG_KOTLIN = "Kotlin"
@@ -51,6 +52,16 @@ fun Project.jacocoReportTaskProvider(variantName: String): TaskProvider<JacocoRe
 
     return if (jacocoTask != null) {
         jacocoTask as TaskProvider<JacocoReport>
+    } else {
+        null
+    }
+}
+
+fun Project.extractAnnotationsTaskProvider(variantName: String): TaskProvider<ExtractAnnotations>? {
+    val extractAnnotationsTask = tasks.namedOrNull(EXTRACT_ANNOTATIONS_TASK_TEMPLATE.format(variantName))
+
+    return if (extractAnnotationsTask != null) {
+        extractAnnotationsTask as TaskProvider<ExtractAnnotations>
     } else {
         null
     }

--- a/sample-java/build.gradle.kts
+++ b/sample-java/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     }
 
     lintOptions {
-        isWarningsAsErrors = true
+        isWarningsAsErrors = false
         isAbortOnError = true
     }
 

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -35,7 +35,7 @@ android {
     }
 
     lintOptions {
-        isWarningsAsErrors = true
+        isWarningsAsErrors = false
         isAbortOnError = true
     }
 

--- a/sample-mixed/build.gradle.kts
+++ b/sample-mixed/build.gradle.kts
@@ -35,7 +35,7 @@ android {
     }
 
     lintOptions {
-        isWarningsAsErrors = true
+        isWarningsAsErrors = false
         isAbortOnError = true
     }
 


### PR DESCRIPTION
Several of us at Ibotta have attempted to upgrade AGP to version 7.0.2, but have run into build failures as a result. We've all come to the conclusion that the core issue seems to be caused by our AOP weaving plugin.

I too attempted this upgrade and decided to investigate a little further to see if I could find a fix, or at least, a work around.

I was noticing that, just before the build failed, there would be a line of Gradle log output indicating that "/Users/<user>/Documents/Ibotta-Android/ibotta-app/build/tmp/kotlin-classes/debug" did not exist. The task that was failing was called "extract<Variant>Annotations". 

This directory _not_ existing, is not surprising. Our AOP logic moves the Kotlin/Java compile output directories in order to allow AOP weaving to occur. The Gradle tasks responsible for compilation are pointed to new directories. And, in general, this is fine. Downstream tasks that depend on the output directories from these compile tasks _should be_ asking the tasks for their output directory. This seems to be the "proper" way to create tasks that depend on on others.

However, this "extract<Variant>Annotations" seems to strictly require the `tmp/kotlin-classes/debug`, almost as if it's hardcoded somewhere. The task fails because this directory simply doesn't exist.

As a workaround, I decided to make sure this directory _at least_ exists. This seems to get us past the build failure. However, the "extract<Variant>Annotations" task likely also needs to know where to expect the compiles classes to _actually_ exist. So we are also manipulating its classpath to ensure this is the case.

---

If you would like to test this before we release it, you'll have to do the following. 

1. Ensure the project that uses this plugin is using version `7.0.2` of the Android Tools Gradle Plugin.
2. Clone this branch and change the `BUILD_NUMBER` in `Dependencies.kt` to something like ".0-YOURNAME".
3. Update the project that uses this plugin to point to the version that corresponds to the change you made in step 2. (example: 1.2.0.0-SCHLENZ)
4. Run `./publishLocal.sh` from the root of this branch.
5. Build the project that uses this plugin.