### PR TITLE
[AT-3077] Update deps and eliminate JCenter refs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         mavenLocal()
         maven("https://plugins.gradle.org/m2/")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
     `kotlin-dsl`
 }
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -40,7 +40,7 @@ object Versions {
     const val ANDROID_BUILD_TOOLS_VERSION = "7.0.4"
     const val APPCOMPAT_VERSION = "1.4.1"
     const val ASPECTJ_VERSION = "1.9.6"
-    const val GRADLE_PLUGIN_PUBLISH_VERSION = "0.16.0"
+    const val GRADLE_PLUGIN_PUBLISH_VERSION = "0.20.0"
     const val JACOCO_ANDROID_VERSION = "0.2"
     const val JUNIT_VERSION = "5.8.2"
     const val KOTLIN_VERSION = "1.6.10"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Plugin {
     const val DISPLAY_NAME = "Android AspectJ Gradle Plugin"
     const val JVM_TARGET = "1.8"
     private const val BUILD_NUMBER = "" // Dynamically updated by publishLocal.sh on Travis. Otherwise left as-is.
-    const val VERSION = "1.2.0$BUILD_NUMBER"
+    const val VERSION = "1.3.0$BUILD_NUMBER"
     val TAGS = listOf("Gradle", "Plugin", "Android", "AspectJ", "Kotlin", "Java")
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -32,22 +32,22 @@ object JavaApp {
 
 object Sdk {
     const val MIN_SDK_VERSION = 21
-    const val TARGET_SDK_VERSION = 29
-    const val COMPILE_SDK_VERSION = 29
+    const val TARGET_SDK_VERSION = 31
+    const val COMPILE_SDK_VERSION = 31
 }
 
 object Versions {
-    const val ANDROID_BUILD_TOOLS_VERSION = "7.0.2"
-    const val APPCOMPAT_VERSION = "1.1.0"
+    const val ANDROID_BUILD_TOOLS_VERSION = "7.0.4"
+    const val APPCOMPAT_VERSION = "1.4.1"
     const val ASPECTJ_VERSION = "1.9.6"
-    const val GRADLE_PLUGIN_PUBLISH_VERSION = "0.12.0"
+    const val GRADLE_PLUGIN_PUBLISH_VERSION = "0.16.0"
     const val JACOCO_ANDROID_VERSION = "0.2"
-    const val JUNIT_VERSION = "5.7.0"
-    const val KOTLIN_VERSION = "1.4.10"
-    const val KOTLIN_DSL_VERSION = "2.1.6"
+    const val JUNIT_VERSION = "5.8.2"
+    const val KOTLIN_VERSION = "1.6.10"
+    const val KOTLIN_DSL_VERSION = "2.2.0"
     const val KOTLINX_SERIALIZATION_RUNTIME_VERSION = "0.20.0"
-    const val MOCKITO_CORE_VERSION = "3.5.13"
-    const val MOCKK_VERSION = "1.10.2"
+    const val MOCKITO_CORE_VERSION = "4.2.0"
+    const val MOCKK_VERSION = "1.12.2"
 }
 
 object SupportLibs {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Plugin {
     const val DISPLAY_NAME = "Android AspectJ Gradle Plugin"
     const val JVM_TARGET = "1.8"
     private const val BUILD_NUMBER = "" // Dynamically updated by publishLocal.sh on Travis. Otherwise left as-is.
-    const val VERSION = "1.3.0$BUILD_NUMBER"
+    const val VERSION = "1.2.0$BUILD_NUMBER"
     val TAGS = listOf("Gradle", "Plugin", "Android", "AspectJ", "Kotlin", "Java")
 }
 

--- a/sample-java/src/main/AndroidManifest.xml
+++ b/sample-java/src/main/AndroidManifest.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
-      package="com.ibotta.gradle.aop.java">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.ibotta.gradle.aop.java">
 
     <application
-            android:allowBackup="true"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:theme="@style/Theme.AppCompat.DayNight"
-            tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.DayNight"
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
 
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
-      package="com.ibotta.gradle.aop.kotlin">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.ibotta.gradle.aop.kotlin">
 
     <application
-            android:allowBackup="true"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:theme="@style/Theme.AppCompat.DayNight"
-            tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.DayNight"
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
 
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 

--- a/sample-mixed/src/main/AndroidManifest.xml
+++ b/sample-mixed/src/main/AndroidManifest.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
-      package="com.ibotta.gradle.aop.mixed">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.ibotta.gradle.aop.mixed">
 
     <application
-            android:allowBackup="true"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:theme="@style/Theme.AppCompat.DayNight"
-            tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.DayNight"
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
 
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,6 @@ pluginManagement {
         google()
         mavenCentral()
         mavenLocal()
-        jcenter()
         maven("https://plugins.gradle.org/m2/")
     }
 }


### PR DESCRIPTION
This PR is an attempt to resolve issue #15.

It was reported by one of our AOP Plugin users that our references to JCenter were causing them some issues. Luckily, this project is light enough that we can easily remedy this issue.

From the Gradle documentation:

> Impact to Gradle plugins
> Behind the scenes, the Gradle Plugin Portal uses JCenter to resolve dependencies of plugins. We will be migrating the Plugin Portal away from JCenter before the final shutdown. Builds will not need to make changes while the Plugin Portal migrates away from JCenter.

> Resolving existing plugins
> Existing plugins will continue to resolve in the same way they do today. No changes should need to be made to your builds.

> Publishing new or updated plugins
> If you are publishing your plugin with the com.gradle.plugin-publish, you are not affected. Just double check that your build
does not use JCenter directly.

> If you are publishing your plugin to Bintray, you will need to use the com.gradle.plugin-publish plugin to publish new versions
of your plugin. The sooner you can do this, the better. We can help if you have questions or problems.

> We will automatically migrate all plugins published to Bintray on March 31, 2021. After that date, we will no longer
synchronize plugins published to Bintray. This migration should be transparent to users resolving dependencies.
