### PR TITLE
Add regexpFilter extension property

### DIFF
--- a/plugin/src/main/kotlin/com/ibotta/gradle/aop/AopWeaveExtension.kt
+++ b/plugin/src/main/kotlin/com/ibotta/gradle/aop/AopWeaveExtension.kt
@@ -6,4 +6,5 @@ open class AopWeaveExtension {
     }
 
     var filter = ""
+    var regexpFilter = ""
 }

--- a/plugin/src/main/kotlin/com/ibotta/gradle/aop/PipelineAopWeaverPlugin.kt
+++ b/plugin/src/main/kotlin/com/ibotta/gradle/aop/PipelineAopWeaverPlugin.kt
@@ -285,12 +285,21 @@ class PipelineAopWeaverPlugin : Plugin<Project> {
             aspectPathResolver = {
                 project.files(gatherAspectPaths(project, variantNameCapitalized, preWeaveJavaDir, preWeaveKotlinDir))
                     .also {
-                        if (extension.filter.isNotEmpty()) {
+                        if (extension.regexpFilter.isNotEmpty()) {
+                            project.aopLog("Weaving regexp filter in ${project.name} is: ${extension.regexpFilter}")
+                        } else if (extension.filter.isNotEmpty()) {
                             project.aopLog("Weaving filter in ${project.name} is: ${extension.filter}")
                         }
                     }
                     .filter { file ->
-                        file.canonicalPath.contains(extension.filter)
+                        var includeFile = true;
+                        if (extension.regexpFilter.isNotEmpty()) {
+                            includeFile = file.canonicalPath.contains(Regex(extension.regexpFilter))
+                        } else if (extension.filter.isNotEmpty()) {
+                            includeFile = file.canonicalPath.contains(extension.filter)
+                        }
+                        if (includeFile) project.aopLog("Weaving file: ${file.canonicalPath}")
+                        return@filter includeFile
                     }
             }
             classPathResolver = { gatherClasspaths(project, variantNameCapitalized) }


### PR DESCRIPTION
This property when set will take precedence on the existing filter one.
It allows for one to provide a regular expression that will be used to
filter the file paths to include when weaving the files in the project.

This can be useful when one want to weave the code in the project as
well as specific libraries.