### PR TITLE
#24 : Fix issue with Kotlin 1.7.0 changing the KotlinCompileTask to no longer inherit from AbstractCompile

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,13 +37,13 @@ object Sdk {
 }
 
 object Versions {
-    const val ANDROID_BUILD_TOOLS_VERSION = "7.0.4"
+    const val ANDROID_BUILD_TOOLS_VERSION = "7.2.1"
     const val APPCOMPAT_VERSION = "1.4.1"
-    const val ASPECTJ_VERSION = "1.9.6"
+    const val ASPECTJ_VERSION = "1.9.7"
     const val GRADLE_PLUGIN_PUBLISH_VERSION = "0.20.0"
     const val JACOCO_ANDROID_VERSION = "0.2"
     const val JUNIT_VERSION = "5.8.2"
-    const val KOTLIN_VERSION = "1.6.10"
+    const val KOTLIN_VERSION = "1.7.0"
     const val KOTLIN_DSL_VERSION = "2.2.0"
     const val KOTLINX_SERIALIZATION_RUNTIME_VERSION = "0.20.0"
     const val MOCKITO_CORE_VERSION = "4.2.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/com/ibotta/gradle/aop/ExtFunctions.kt
+++ b/plugin/src/main/kotlin/com/ibotta/gradle/aop/ExtFunctions.kt
@@ -2,6 +2,7 @@ package com.ibotta.gradle.aop
 
 import com.android.build.gradle.tasks.ExtractAnnotations
 import com.hiya.plugins.JacocoAndroidUnitTestReportExtension
+import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownDomainObjectException
@@ -9,6 +10,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.testing.jacoco.tasks.JacocoReport
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 
 private const val KAPT_TASK_TEMPLATE = "kapt%sKotlin"
@@ -23,20 +25,10 @@ const val LANG_KOTLIN = "Kotlin"
 fun Project.aopLog(msg: String) = logger.warn("/** Ibotta AOP **/: $msg")
 
 fun Project.javaCompileTask(variantName: String): AbstractCompile? =
-    compileTask(JAVA_COMPILE_TASK_TEMPLATE.format(variantName))
+    firstTask(JAVA_COMPILE_TASK_TEMPLATE.format(variantName))  as? AbstractCompile
 
-fun Project.kotlinCompileTask(variantName: String): AbstractCompile? =
-    compileTask(KOTLIN_COMPILE_TASK_TEMPLATE.format(variantName))
-
-private fun Project.compileTask(taskName: String): AbstractCompile? {
-    val firstTask = firstTask(taskName)
-
-    return if (firstTask != null) {
-        firstTask as AbstractCompile
-    } else {
-        null
-    }
-}
+fun Project.kotlinCompileTask(variantName: String): KotlinCompile? =
+    firstTask(KOTLIN_COMPILE_TASK_TEMPLATE.format(variantName)) as? KotlinCompile?
 
 fun Project.kaptTaskProvider(variantName: String) =
     tasks.namedOrNull(KAPT_TASK_TEMPLATE.format(variantName))

--- a/sample-java/build.gradle.kts
+++ b/sample-java/build.gradle.kts
@@ -32,9 +32,9 @@ android {
         }
     }
 
-    lintOptions {
-        isWarningsAsErrors = false
-        isAbortOnError = true
+    lint {
+        warningsAsErrors = false
+        abortOnError = true
     }
 
     sourceSets.getByName("main") {

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -34,9 +34,9 @@ android {
         }
     }
 
-    lintOptions {
-        isWarningsAsErrors = false
-        isAbortOnError = true
+    lint {
+        warningsAsErrors = false
+        abortOnError = true
     }
 
     sourceSets.getByName("main") {

--- a/sample-mixed/build.gradle.kts
+++ b/sample-mixed/build.gradle.kts
@@ -34,9 +34,9 @@ android {
         }
     }
 
-    lintOptions {
-        isWarningsAsErrors = false
-        isAbortOnError = true
+    lint {
+        warningsAsErrors = false
+        abortOnError = true
     }
 
     sourceSets.getByName("main") {


### PR DESCRIPTION
#24 : Fix issue with Kotlin 1.7.0 changing the KotlinCompileTask to no longer inherit from AbstractCompile

feat : This fixes the error by checking if the task is a KotlinCompile or AbstractCompile task.
This also updates the Kotlin and Gradle plugin versions accordingly.

@eschlenz This seems to fix #24 for me when I tried on my personal project using mavenLocal but some more eyes on it would be helpful because I'm not totally sure if I missed anything. Thanks!
